### PR TITLE
Fix vendingstat_npcshop for Vend_SQL plugin

### DIFF
--- a/Yommy/Vend_SQL/Vend_SQL.c
+++ b/Yommy/Vend_SQL/Vend_SQL.c
@@ -164,7 +164,7 @@ void do_init_vendingstat(void)
 				"`card1` smallint(6) NOT NULL,"
 				"`card2` smallint(6) NOT NULL,"
 				"`card3` smallint(6) NOT NULL,"
-				"`amount` int(10) unsigned NOT NULL,"
+				"`amount` int(10) NOT NULL,"
 				"`price` int(10) unsigned NOT NULL)",
 				vendingstat_table)
 	) {


### PR DESCRIPTION
Server mode: Pre-renewal
Not test on Renewal yet

#### Error:
```sh
[SQL]: DB error - Out of range value for column 'amount' at row 3
[Debug]: at Vend_SQL.c:142 - INSERT DELAYED INTO `vending_stat` (`type`,`owner`,`shop`,`map`,`x`,`y`,`nameid`,`refine`,`card0`,`card1`,`card2`,`card3`,`amount`,`price`) VALUES ('0','Machan','Ahihi','prontera','148','184','1201','0','4029','0','0','4703','1','1000'),('0','Machan','Ahihi','prontera','148','184','512','0','0','0','0','0','100','30'),('2','Potato Merchant','','new_1-2','28','185','516','0','0','0','0','0','-1','15'),('2','Cave Girl','','cave','76','39','712','0','0','0','0','0','-1','2'),('2','Turbo Track Merchant','','turbo_room','124','86','501','0','0','0','0','0','-1','50'),('2','Turbo Track Merchant','','turbo_room','124','86','502','0','0','0','0','0','-1','200'),('2','Turbo Track Merchant','','turbo_room','124','86','503','0','0','0','0','0','-1','550'),('2','Turbo Track Merchant','','turbo_room','124','86','504','0','0','0','0','0','-1','1200'),('2','Turbo Track Merchant','','turbo_room','124','86','645','0','0','0','0','0','-1','800'),('2','Turbo Track Merchant','','turbo_room','124','86','656','0','0','0','0','0','-1','1500'),('2','Turbo Track Merchant','','turbo_room','124','86','1065','0','0','0','0','0','-1','100'),('2','Turbo Track Merchant','','turbo_room','124','86','1750','0','0','0','0','0','-1','1')
```

#### SQL qurey has excute:
```sql
INSERT DELAYED INTO `vending_stat` (`type`, `owner`, `shop`, `map`, `x`, `y`, `nameid`, `refine`, `card0`, `card1`, `card2`, `card3`, `amount`, `price`)
VALUES ('0','Machan','Ahihi','prontera','148','184','1201','0','4029','0','0','4703','1','1000'),
       ('0','Machan','Ahihi','prontera','148','184','512','0','0','0','0','0','100','30'),
       ('2','Potato Merchant','','new_1-2','28','185','516','0','0','0','0','0','-1','15'),
       ('2','Cave Girl','','cave','76','39','712','0','0','0','0','0','-1','2'),
       ('2','Turbo Track Merchant','','turbo_room','124','86','501','0','0','0','0','0','-1','50'),
       ('2','Turbo Track Merchant','','turbo_room','124','86','502','0','0','0','0','0','-1','200'),
       ('2','Turbo Track Merchant','','turbo_room','124','86','503','0','0','0','0','0','-1','550'),
       ('2','Turbo Track Merchant','','turbo_room','124','86','504','0','0','0','0','0','-1','1200'),
       ('2','Turbo Track Merchant','','turbo_room','124','86','645','0','0','0','0','0','-1','800'),
       ('2','Turbo Track Merchant','','turbo_room','124','86','656','0','0','0','0','0','-1','1500'),
       ('2','Turbo Track Merchant','','turbo_room','124','86','1065','0','0','0','0','0','-1','100'),
       ('2','Turbo Track Merchant','','turbo_room','124','86','1750','0','0','0','0','0','-1','1')
```

From line 3 are NPC shop with `amount = -1`. But table `vending_stat` define field `amount` with unsigned. This pull request remove `unsigned` for `amount` field.